### PR TITLE
use the collection id (less the key) as the assembly name instead of …

### DIFF
--- a/scripts/process_collections.py
+++ b/scripts/process_collections.py
@@ -142,8 +142,8 @@ class ProcessCollections:
                 ### possibly break out next section into methods: blast, jbrowse, then types
                 if collection_type == "genomes":  # add genome
                     if mode == "jbrowse":  # for jbrowse
-                        cmd = f"jbrowse add-assembly -a {name} --out {self.out_dir}/ -t bgzipFasta --force"
-                        cmd += f' -n "{genus.capitalize()} {species} {infraspecies} {collection_type.capitalize()}" {url}'
+                        cmd = f"jbrowse add-assembly -n {name} --out {self.out_dir}/ -t bgzipFasta --force"
+                        cmd += f' --displayName "{genus.capitalize()} {species} {infraspecies} {collection_type.capitalize()}" {url}'
                     elif mode == "blast":  # for blast
                         cmd = f"set -o pipefail -o errexit -o nounset; curl {url} | gzip -dc"  # retrieve genome and decompress
                         cmd += f'| makeblastdb -parse_seqids -out {self.out_dir}/{name} -hash_index -dbtype nucl -title "{genus.capitalize()} {species} {infraspecies} {collection_type.capitalize()}"'


### PR DESCRIPTION
…as an alias, so that other parts of the system that don't understand aliasing will work properly (#14). "human readable" specification for collection becomes --displayName. Left the call to add-track as is, since the same considerations don't seem to apply.